### PR TITLE
chore: extract NodeMetadata as a standalone type+schema

### DIFF
--- a/src/main/model/graph.ts
+++ b/src/main/model/graph.ts
@@ -7,14 +7,8 @@ export class Graph implements t.Graph {
 
     static schema = GraphSchema;
 
-    label!: string;
-    category!: string[];
-    description!: string;
-    deprecated!: string;
-    hidden!: boolean;
+    metadata!: t.NodeMetadata;
     rootNodeId!: string;
-    params: Record<string, t.ParamMetadata> = {};
-    result: t.DataSchema<any> = { type: 'any' };
     nodes: Node[];
     refs: Record<string, string> = {};
 

--- a/src/main/model/node.ts
+++ b/src/main/model/node.ts
@@ -221,7 +221,7 @@ export class Node implements t.Node {
 
     protected initProps(specs: t.Prop[]) {
         const props: Prop[] = [];
-        for (const key of Object.keys(this.$def.params)) {
+        for (const key of Object.keys(this.$def.metadata.params)) {
             const spec = specs.find(_ => _.key === key) ?? { key };
             const prop = new Prop(this, spec);
             props.push(prop);

--- a/src/main/model/prop.ts
+++ b/src/main/model/prop.ts
@@ -49,7 +49,7 @@ export class Prop implements t.Prop {
     }
 
     get $param(): t.ParamMetadata {
-        return this.$node.$def.params[this.$paramKey] ?? {
+        return this.$node.$def.metadata.params[this.$paramKey] ?? {
             schema: { type: 'any' },
         };
     }

--- a/src/main/nodes/comment.ts
+++ b/src/main/nodes/comment.ts
@@ -3,15 +3,17 @@ import * as t from '../types/index.js';
 export const Comment: t.Operator<{
     comment: string;
 }, any> = {
-    label: 'Comment',
-    category: ['Graph'],
-    params: {
-        comment: {
-            schema: {
-                type: 'string'
-            },
-        }
+    metadata: {
+        label: 'Comment',
+        category: ['Graph'],
+        params: {
+            comment: {
+                schema: {
+                    type: 'string'
+                },
+            }
+        },
+        result: { type: 'any' },
     },
-    result: { type: 'any' },
     compute() {},
 };

--- a/src/main/nodes/local.ts
+++ b/src/main/nodes/local.ts
@@ -3,15 +3,17 @@ import * as t from '../types/index.js';
 export const Local: t.Operator<{
     key: string;
 }, any> = {
-    label: 'Local',
-    category: ['Graph'],
-    params: {
-        key: {
-            schema: {
-                type: 'string',
-            },
-        }
+    metadata: {
+        label: 'Local',
+        category: ['Graph'],
+        params: {
+            key: {
+                schema: {
+                    type: 'string',
+                },
+            }
+        },
+        result: { type: 'any' },
     },
-    result: { type: 'any' },
     compute() {}
 };

--- a/src/main/nodes/param.ts
+++ b/src/main/nodes/param.ts
@@ -3,16 +3,18 @@ import * as t from '../types/index.js';
 export const Param: t.Operator<{
     key: string;
 }, any> = {
-    label: 'Parameter',
-    category: ['Graph'],
-    params: {
-        key: {
-            schema: {
-                type: 'string',
-                kind: 'param',
-            },
-        }
+    metadata: {
+        label: 'Parameter',
+        category: ['Graph'],
+        params: {
+            key: {
+                schema: {
+                    type: 'string',
+                    kind: 'param',
+                },
+            }
+        },
+        result: { type: 'any' },
     },
-    result: { type: 'any' },
     compute() {}
 };

--- a/src/main/nodes/result.ts
+++ b/src/main/nodes/result.ts
@@ -3,15 +3,17 @@ import * as t from '../types/index.js';
 export const Result: t.Operator<{
     value: any;
 }, any> = {
-    label: 'Result',
-    category: ['Graph'],
-    params: {
-        value: {
-            schema: {
-                type: 'any',
-            },
-        }
+    metadata: {
+        label: 'Result',
+        category: ['Graph'],
+        params: {
+            value: {
+                schema: {
+                    type: 'any',
+                },
+            }
+        },
+        result: { type: 'any' },
     },
-    result: { type: 'any' },
     compute() {},
 };

--- a/src/main/schema/graph.ts
+++ b/src/main/schema/graph.ts
@@ -1,39 +1,14 @@
 import { Schema } from 'airtight';
 
 import * as t from '../types/index.js';
-import { DataSchemaSchema } from './data-schema.js';
 import { NodeSchema } from './node.js';
-import { ParamMetadataSchema } from './param-metadata.js';
+import { NodeMetadataSchema } from './node-metadata.js';
 
 export const GraphSchema = new Schema<t.Graph>({
     id: 'Graph',
     type: 'object',
     properties: {
-        label: {
-            type: 'string',
-        },
-        category: {
-            type: 'array',
-            items: {
-                type: 'string'
-            }
-        },
-        description: {
-            type: 'string',
-        },
-        deprecated: {
-            type: 'string',
-        },
-        hidden: {
-            type: 'boolean',
-        },
-        params: {
-            type: 'object',
-            properties: {},
-            additionalProperties: ParamMetadataSchema.schema,
-        },
-        result: DataSchemaSchema.schema as any,
-        compute: { type: 'any' },
+        metadata: NodeMetadataSchema.schema,
         nodes: {
             type: 'array',
             items: NodeSchema.schema,

--- a/src/main/schema/index.ts
+++ b/src/main/schema/index.ts
@@ -2,6 +2,7 @@
 export * from './data-schema.js';
 export * from './graph.js';
 export * from './node-def.js';
+export * from './node-metadata.js';
 export * from './node-result.js';
 export * from './node.js';
 export * from './param-metadata.js';

--- a/src/main/schema/node-def.ts
+++ b/src/main/schema/node-def.ts
@@ -1,26 +1,13 @@
 import { Schema } from 'airtight';
 
 import * as t from '../types/index.js';
-import { DataSchemaSchema } from './data-schema.js';
-import { ParamMetadataSchema } from './param-metadata.js';
+import { NodeMetadataSchema } from './node-metadata.js';
 
 export const NodeDefSchema = new Schema<t.NodeDef>({
+    id: 'NodeDef',
     type: 'object',
     properties: {
-        label: { type: 'string' },
-        category: {
-            type: 'array',
-            items: { type: 'string' },
-        },
-        description: { type: 'string' },
-        deprecated: { type: 'string' },
-        hidden: { type: 'boolean' },
-        params: {
-            type: 'object',
-            properties: {},
-            additionalProperties: ParamMetadataSchema.schema,
-        },
-        result: DataSchemaSchema.schema as any,
+        metadata: NodeMetadataSchema.schema,
         compute: { type: 'any' },
-    }
+    },
 });

--- a/src/main/schema/node-metadata.ts
+++ b/src/main/schema/node-metadata.ts
@@ -1,0 +1,26 @@
+import { Schema } from 'airtight';
+
+import * as t from '../types/index.js';
+import { DataSchemaSchema } from './data-schema.js';
+import { ParamMetadataSchema } from './param-metadata.js';
+
+export const NodeMetadataSchema = new Schema<t.NodeMetadata>({
+    id: 'NodeMetadata',
+    type: 'object',
+    properties: {
+        label: { type: 'string' },
+        category: {
+            type: 'array',
+            items: { type: 'string' },
+        },
+        description: { type: 'string' },
+        deprecated: { type: 'string' },
+        hidden: { type: 'boolean' },
+        params: {
+            type: 'object',
+            properties: {},
+            additionalProperties: ParamMetadataSchema.schema,
+        },
+        result: DataSchemaSchema.schema as any,
+    }
+});

--- a/src/main/types/defs.ts
+++ b/src/main/types/defs.ts
@@ -1,7 +1,7 @@
 import { GraphEvalContext } from './ctx.js';
 import { DataSchema } from './data.js';
 
-export type NodeDef = {
+export type NodeMetadata = {
     label: string;
     category: string[];
     description: string;
@@ -9,19 +9,24 @@ export type NodeDef = {
     hidden: boolean;
     params: Record<string, ParamDef>;
     result: DataSchema<any>;
+};
+
+export type NodeDef = {
+    metadata: NodeMetadata;
     compute: (...args: any[]) => any;
 };
 
 export type Operator<Params = any, Result = any> = {
-    label: string;
-    category?: string[];
-    description?: string;
-    deprecated?: string;
-    hidden?: boolean;
-    params: ParamDefs<Params>;
-    result: DataSchema<Result>;
+    metadata: OperatorMetadata<Params, Result>;
     compute: NodeCompute<Params, Result>;
 };
+
+export type OperatorMetadata<Params = any, Result = any> =
+    Partial<NodeMetadata> & {
+        label: string;
+        params: ParamDefs<Params>;
+        result: DataSchema<Result>;
+    };
 
 export type NodeCompute<P, R> = (this: void, params: P, ctx: GraphEvalContext) => R | Promise<R>;
 

--- a/src/main/types/model.ts
+++ b/src/main/types/model.ts
@@ -1,7 +1,8 @@
 import { DeepPartial } from './deep-partial.js';
-import { NodeDef } from './defs.js';
+import { NodeMetadata } from './defs.js';
 
-export interface Graph extends NodeDef {
+export interface Graph {
+    metadata: NodeMetadata;
     nodes: Node[];
     rootNodeId: string;
     refs: Record<string, string>;

--- a/src/test/defs/any.ts
+++ b/src/test/defs/any.ts
@@ -3,17 +3,19 @@ import { Operator } from '../../main/types/defs.js';
 export const node: Operator<{
     value: unknown;
 }, unknown> = {
-    label: 'Any',
-    description: 'Just returns the value as is, without type conversion.',
-    params: {
-        value: {
-            schema: {
-                type: 'any'
-            }
+    metadata: {
+        label: 'Any',
+        description: 'Just returns the value as is, without type conversion.',
+        params: {
+            value: {
+                schema: {
+                    type: 'any'
+                }
+            },
         },
-    },
-    result: {
-        type: 'any',
+        result: {
+            type: 'any',
+        },
     },
     compute(params) {
         return params.value;

--- a/src/test/defs/array.ts
+++ b/src/test/defs/array.ts
@@ -3,21 +3,23 @@ import { Operator } from '../../main/types/defs.js';
 export const node: Operator<{
     items: any[];
 }, any[]> = {
-    label: 'Array',
-    description: 'Creates an array.',
-    params: {
-        items: {
-            schema: {
-                type: 'array',
-                items: {
-                    type: 'any',
-                },
-            }
+    metadata: {
+        label: 'Array',
+        description: 'Creates an array.',
+        params: {
+            items: {
+                schema: {
+                    type: 'array',
+                    items: {
+                        type: 'any',
+                    },
+                }
+            },
         },
-    },
-    result: {
-        type: 'array',
-        items: { type: 'any' },
+        result: {
+            type: 'array',
+            items: { type: 'any' },
+        },
     },
     compute(params) {
         return params.items;

--- a/src/test/defs/lambda.map.ts
+++ b/src/test/defs/lambda.map.ts
@@ -4,27 +4,29 @@ export const node: Operator<{
     array: unknown[];
     fn: Lambda<{ item: unknown; index: number }, unknown>;
 }, unknown[]> = {
-    label: 'Lambda.Map',
-    description: 'Executes a function for each array element and returns an array of results.',
-    params: {
-        array: {
-            schema: {
-                type: 'array',
-                items: { type: 'any' },
+    metadata: {
+        label: 'Lambda.Map',
+        description: 'Executes a function for each array element and returns an array of results.',
+        params: {
+            array: {
+                schema: {
+                    type: 'array',
+                    items: { type: 'any' },
+                },
             },
-        },
-        fn: {
-            kind: 'lambda',
-            schema: { type: 'any' },
-            scope: {
-                item: { type: 'any' },
-                index: { type: 'number' },
+            fn: {
+                kind: 'lambda',
+                schema: { type: 'any' },
+                scope: {
+                    item: { type: 'any' },
+                    index: { type: 'number' },
+                }
             }
-        }
-    },
-    result: {
-        type: 'array',
-        items: { type: 'any' },
+        },
+        result: {
+            type: 'array',
+            items: { type: 'any' },
+        },
     },
     async compute(params) {
         const result: unknown[] = [];

--- a/src/test/defs/math.add.ts
+++ b/src/test/defs/math.add.ts
@@ -4,22 +4,24 @@ export const node: Operator<{
     a: number;
     b: number;
 }, number> = {
-    label: 'Math.Add',
-    description: 'Computes a sum of two numbers.',
-    params: {
-        a: {
-            schema: {
-                type: 'number'
+    metadata: {
+        label: 'Math.Add',
+        description: 'Computes a sum of two numbers.',
+        params: {
+            a: {
+                schema: {
+                    type: 'number'
+                }
+            },
+            b: {
+                schema: {
+                    type: 'number'
+                }
             }
         },
-        b: {
-            schema: {
-                type: 'number'
-            }
-        }
-    },
-    result: {
-        type: 'number',
+        result: {
+            type: 'number',
+        },
     },
     compute(params) {
         return params.a + params.b;

--- a/src/test/defs/number.ts
+++ b/src/test/defs/number.ts
@@ -3,17 +3,19 @@ import { Operator } from '../../main/types/defs.js';
 export const node: Operator<{
     value: unknown;
 }, number> = {
-    label: 'Number',
-    description: 'Converts the value into a number.',
-    params: {
-        value: {
-            schema: {
-                type: 'any'
-            }
+    metadata: {
+        label: 'Number',
+        description: 'Converts the value into a number.',
+        params: {
+            value: {
+                schema: {
+                    type: 'any'
+                }
+            },
         },
-    },
-    result: {
-        type: 'number',
+        result: {
+            type: 'number',
+        },
     },
     compute(params) {
         return Number(params.value);

--- a/src/test/defs/object.ts
+++ b/src/test/defs/object.ts
@@ -3,17 +3,19 @@ import { Operator } from '../../main/types/defs.js';
 export const node: Operator<{
     properties: any;
 }, any> = {
-    label: 'Object',
-    description: 'Creates an object.',
-    params: {
-        properties: {
-            schema: {
-                type: 'object',
-            }
+    metadata: {
+        label: 'Object',
+        description: 'Creates an object.',
+        params: {
+            properties: {
+                schema: {
+                    type: 'object',
+                }
+            },
         },
-    },
-    result: {
-        type: 'object',
+        result: {
+            type: 'object',
+        },
     },
     compute(params) {
         return params.properties;

--- a/src/test/defs/string.ts
+++ b/src/test/defs/string.ts
@@ -3,17 +3,19 @@ import { Operator } from '../../main/types/defs.js';
 export const node: Operator<{
     value: unknown;
 }, string> = {
-    label: 'String',
-    description: 'Converts the value into a string.',
-    params: {
-        value: {
-            schema: {
-                type: 'any'
-            }
+    metadata: {
+        label: 'String',
+        description: 'Converts the value into a string.',
+        params: {
+            value: {
+                schema: {
+                    type: 'any'
+                }
+            },
         },
-    },
-    result: {
-        type: 'string',
+        result: {
+            type: 'string',
+        },
     },
     compute(params) {
         return String(params.value);

--- a/src/test/runtime/compiler.test.ts
+++ b/src/test/runtime/compiler.test.ts
@@ -109,15 +109,17 @@ describe('GraphCompiler', () => {
         it('can compile graph and use it as a node', async () => {
             const loader = await runtime.createLoader();
             const graph1 = await loader.loadGraph({
+                metadata: {
+                    params: {
+                        val: {
+                            schema: { type: 'number' },
+                        }
+                    },
+                    result: {
+                        type: 'number',
+                    },
+                },
                 rootNodeId: 'res',
-                params: {
-                    val: {
-                        schema: { type: 'number' },
-                    }
-                },
-                result: {
-                    type: 'number',
-                },
                 nodes: [
                     {
                         id: 'p1',

--- a/src/test/runtime/loader.test.ts
+++ b/src/test/runtime/loader.test.ts
@@ -8,14 +8,18 @@ describe('GraphLoader', () => {
     it('loads modules from URL', async () => {
         const loader = new GraphLoader();
         const def = await loader.loadNodeDef(runtime.defs['math.add']);
-        assert.deepStrictEqual(def.label, 'Math.Add');
-        assert.deepStrictEqual(def.category, []);
-        assert.deepStrictEqual(def.description, 'Computes a sum of two numbers.');
-        assert.deepStrictEqual(def.params, {
-            a: { schema: { type: 'number' } },
-            b: { schema: { type: 'number' } },
+        assert.deepStrictEqual(def.metadata, {
+            label: 'Math.Add',
+            category: [],
+            description: 'Computes a sum of two numbers.',
+            deprecated: '',
+            hidden: false,
+            params: {
+                a: { schema: { type: 'number' } },
+                b: { schema: { type: 'number' } },
+            },
+            result: { type: 'number' },
         });
-        assert.deepStrictEqual(def.result, { type: 'number' });
         assert.strictEqual(typeof def.compute, 'function');
     });
 
@@ -30,7 +34,7 @@ describe('GraphLoader', () => {
             }
         });
         const def = loader.resolveNodeDef(runtime.defs['math.add']);
-        assert.deepStrictEqual(def.label, 'Math.Add');
+        assert.deepStrictEqual(def.metadata.label, 'Math.Add');
         assert.strictEqual(typeof def.compute, 'function');
     });
 
@@ -53,7 +57,7 @@ describe('GraphLoader', () => {
         });
         const node = graph.getNodeById('node1');
         const def = node!.$def;
-        assert.deepStrictEqual(def.label, 'Math.Add');
+        assert.deepStrictEqual(def.metadata.label, 'Math.Add');
         assert.strictEqual(typeof def.compute, 'function');
     });
 


### PR DESCRIPTION
This PR introduces a dedicated type `NodeMetadata` to hold static information about node modules (i.e. a label, description, param/result descriptors, etc).

These fields will likely be used to display information about nodes, so it's much more convenient to have metadata as a standalone entity (vs. plucking the fields from a bigger `NodeDef` object). We further expect to add more fields like `keywords` to it.